### PR TITLE
Only build releases on build of the tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
                     }
                 }
             }
+
             steps {
                 withCredentials([
                     usernamePassword(credentialsId: 'ossrh', usernameVariable: 'OSSRH_USERNAME', passwordVariable: 'OSSRH_TOKEN'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,21 @@ pipeline {
         }
         stage ('Deploy') {
             when {
-                not {
-                    changeRequest()
+                anyOf {
+                    not {
+                        anyOf {
+                            changeRequest()
+                            buildingTag()
+                            changelog '.*\\[maven-release-plugin\\].*'
+                        }
+                    }
+                    allOf {
+                        not {
+                            changeRequest()
+                        }
+                        buildingTag()
+                        changelog '.*\\[maven-release-plugin\\].*'
+                    }
                 }
             }
             steps {


### PR DESCRIPTION
This prevents jenkins from ignoring a release commit made by release plugin, when he builds multiple commits at once