### PR TITLE
Add default version for failsafe and resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
         <version.maven-shade-plugin>3.5.1</version.maven-shade-plugin>
         <version.sonar-maven-plugin>3.9.1.2184</version.sonar-maven-plugin>
         <version.maven-surefire-plugin>3.2.3</version.maven-surefire-plugin>
+        <version.maven-failsafe-plugin>3.2.3</version.maven-failsafe-plugin>
+        <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
         <version.docker-maven-plugin>0.43.4</version.docker-maven-plugin>
     </properties>
 
@@ -89,6 +91,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.maven-surefire-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${version.maven-failsafe-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.maven-resources-plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
They are currently managed by the default-bindings. Produces Warnings with later maven versions.